### PR TITLE
README: add repo logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# serpapi-search-cpp
+<h1 align="center">Google Search Results in C++</h1>
+
+<div align="center">
+   <img src="https://user-images.githubusercontent.com/78694043/234493320-a9b06273-4264-4540-b5e6-4d1d2e6e4339.svg" width="700" alt="serpapi-search-cpp-logo">
+</div>
+
 
 Extension to search on Google, Bing, HomeDepot, Baidu, Yandex and more using SerpApi written in C++.
 The backend is powered by serpapi.com and required an account


### PR DESCRIPTION
Changes in this PR look like this:

![image](https://user-images.githubusercontent.com/78694043/234493863-3d120cba-c89a-4801-bc89-0aa9ffdd64d0.png)


Additional proposed logo to possibly explore different vector of a look we want:

![serpapi-c++-logo-01](https://user-images.githubusercontent.com/78694043/234494017-15033b9d-cae9-481e-a10e-c7c1c967d3bf.svg)


P.S - SVG images have line aliasing. We can use PNG instead to avoid it.